### PR TITLE
changes the default option for modals to display buttons to true

### DIFF
--- a/src/components/common/InstructionsModal.js
+++ b/src/components/common/InstructionsModal.js
@@ -8,7 +8,7 @@ const InstructionsModal = props => {
     modalVisible,
     style,
     instructions,
-    showOkButton = false,
+    showOkButton = true,
     handleCancel,
     handleOk,
   } = props;
@@ -35,7 +35,7 @@ const InstructionsModal = props => {
         <p style={style}>{instructions}</p>
         {showOkButton && (
           <Button onClick={handleCancel} className="accept-button">
-            I Accept!!!
+            Let's go!
           </Button>
         )}
       </Modal>


### PR DESCRIPTION
# Description

Modals will now display a button that let's users exit out of them more easily. Also modified the button text to display "Let's go!" instead of "I accept!!!"

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, tested, ready to review and merge

## Has This Been Tested

- [x] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
