### PR TITLE
Adds reset button

### DIFF
--- a/src/api/moderation.js
+++ b/src/api/moderation.js
@@ -61,3 +61,14 @@ export const setResults = () => {
     return { err };
   }
 };
+
+export const resetGameForTesting = () => {
+  try {
+    return apiAuthPut('/mod/reset').then(res => {
+      return res;
+    });
+  } catch (err) {
+    console.log(err);
+    return { err };
+  }
+};

--- a/src/components/pages/ModerationTest/ModerationTest.js
+++ b/src/components/pages/ModerationTest/ModerationTest.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'; 
+import React, { useEffect, useState } from 'react';
 
 import {
   getCohorts,
@@ -7,6 +7,7 @@ import {
   setClusters,
   setFaceoffs,
   setResults,
+  resetGameForTesting,
 } from '../../../api/moderation';
 
 import { Button, Layout, PageHeader, Select, Form, Row, Card, Col } from 'antd';
@@ -80,6 +81,13 @@ const ModerationTest = props => {
     });
   };
 
+  // Moderator can reset the game to before cluster generation
+  const reset = () => {
+    resetGameForTesting().then(res => {
+      console.log(res);
+    });
+  };
+
   return (
     <Layout className="moderation-page">
       <PageHeader>
@@ -109,6 +117,9 @@ const ModerationTest = props => {
                 </Button>
                 <Button type="default" onClick={results}>
                   Generate Results
+                </Button>
+                <Button type="default" onClick={reset}>
+                  Reset Game
                 </Button>
               </Form.Item>
             </Form.Item>


### PR DESCRIPTION
# Description
Adds a button that allows moderators to reset the state of the game to before cluster generation. Should only be used during testing

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [ ] No
- [x] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
